### PR TITLE
Type definition for node-modern-rcon.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-rcon",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A modern RCON client implementation written in ES2015",
   "keywords": [
     "rcon",
@@ -9,6 +9,7 @@
     "es6"
   ],
   "main": "rcon.js",
+  "typings": "rcon.d.ts",
   "repository": "levrik/node-modern-rcon",
   "author": "Levin Ricket <me@levrik.io>",
   "license": "MIT",

--- a/rcon.d.ts
+++ b/rcon.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+export declare class RconError extends Error {
+	constructor(message: string);
+}
+
+declare class Rcon {
+
+	constructor(host: string, password: string, timeout?: number);
+	constructor(host: string, port: number, password: string, timeout?: number);
+
+	host: string;
+	port: number;
+	password: string;
+	timeout: number;
+
+	connect(): Promise<void>;
+
+	disconnect(): Promise<void>;
+
+	send(data: string): Promise<string>;
+}
+
+exports = Rcon;


### PR DESCRIPTION
Basic external type declaration that currently reflects `rcon.js`.

@levrik: thank you, and you're welcome. 😁 