### PR TITLE
Fix unable to authenticate when string port is detected.

### DIFF
--- a/rcon.js
+++ b/rcon.js
@@ -28,7 +28,7 @@ class Rcon {
   constructor(host, port, password, timeout) {
     if (!host || !host.trim()) throw new TypeError('"host" argument must be not empty');
     this.host = host;
-    if (typeof port === 'string') {
+    if (isNaN(port)) {
       [port, password, timeout] = [null, port, password];
     }
     this.port = port || 25575;


### PR DESCRIPTION
I was running into serious problems when trying to run this inside of a docker container where environmental variables are all passed in as strings. This would set the password to the port and the timeout to the password and it would never be able to authenticate.